### PR TITLE
Configurando opensearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data
 .idea
 *.iml
 .DS_Store
+*~

--- a/src/main/resources/static/opensearch.xml
+++ b/src/main/resources/static/opensearch.xml
@@ -1,0 +1,12 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+   <ShortName>Serviços de Governo Brasileiro</ShortName>
+   <Description>Procure serviços de governo.</Description>
+   <Tags>serviços governo</Tags>
+   <Contact>govbr@planejamento.gov.br</Contact>
+   <Url type="text/html" 
+        template="http://gds-alpha.herokuapp.com/busca?q={searchTerms}"/>
+   <LongName>Busca de serviços</LongName>
+   <Image height="72" width="72" type="image/png">http://gds-alpha.herokuapp.com/img/touch_icon.png</Image>
+   <Developer>ThoughtWorks</Developer>
+ </OpenSearchDescription>

--- a/src/main/resources/templates/index2.html
+++ b/src/main/resources/templates/index2.html
@@ -5,6 +5,7 @@
 
 <head>
     <title>Bem-vindo!</title>
+    <link rel="search" type="application/opensearchdescription+xml" href="http://gds-alpha.herokuapp.com/opensearch.xml" title="Busca de serviços do governo brasileiro" />
 </head>
 
 <body>


### PR DESCRIPTION
Falta ainda descrever outros itens opcionais se necessário conforme opensearch.org.
Devemos criar um icone 16X16 e outro 64x64 para exibir.