### PR TITLE
Corrigindo o box-sizing da barra brasil

### DIFF
--- a/src/main/assets/stylesheets/_acessibilidade.scss
+++ b/src/main/assets/stylesheets/_acessibilidade.scss
@@ -94,6 +94,7 @@ body.contraste {
   position: absolute;
   top: 0;
   width: 100%;
+  box-sizing: content-box;
 }
 
 #header {


### PR DESCRIPTION
Especificando box-sizing para a barra-brasil.

Não é mais necessário fazer um mixin para box-sizing. O valor 'content-box' é suportado desde IE8. [1]

![captura de tela de 2015-03-19 08 33 14](https://cloud.githubusercontent.com/assets/3831408/6729718/20a01854-ce14-11e4-9e23-99df7f47e7f8.png)

[1] http://caniuse.com/#feat=css3-boxsizing
