### PR TITLE
Trocar "Município" por MDS

### DIFF
--- a/src/main/resources/legado/beneficio-de-prestacao-continuada-bpc.xml
+++ b/src/main/resources/legado/beneficio-de-prestacao-continuada-bpc.xml
@@ -45,7 +45,7 @@ Há duas formas de solicitar o BPC: a pessoa pode agendar o atendimento diretame
         <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
     </orgaoResponsavel>
     <orgaoPrestador>
-        <titulo>Município</titulo>
+        <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
         <endereco></endereco>
         <telefone></telefone>
     </orgaoPrestador>

--- a/src/main/resources/legado/cadastro-unico-para-programas-sociais-do-governo-federal.xml
+++ b/src/main/resources/legado/cadastro-unico-para-programas-sociais-do-governo-federal.xml
@@ -49,7 +49,7 @@ Para sua família ser beneficiada por programas como o Bolsa Família, a Tarifa 
         <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
     </orgaoResponsavel>
     <orgaoPrestador>
-        <titulo>Município</titulo>
+        <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
         <endereco></endereco>
         <telefone></telefone>
     </orgaoPrestador>

--- a/src/main/resources/legado/centro-de-referencia-da-assistencia-social-cras.xml
+++ b/src/main/resources/legado/centro-de-referencia-da-assistencia-social-cras.xml
@@ -35,7 +35,7 @@ Em vários municípios, o CRAS é responsável por inserir as famílias no Cadas
         <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
     </orgaoResponsavel>
     <orgaoPrestador>
-        <titulo>Município</titulo>
+        <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
         <endereco></endereco>
         <telefone></telefone>
     </orgaoPrestador>

--- a/src/main/resources/legado/centro-de-referencia-especializado-da-assistencia-social-creas.xml
+++ b/src/main/resources/legado/centro-de-referencia-especializado-da-assistencia-social-creas.xml
@@ -35,7 +35,7 @@ Além de oferecer proteção e atendimento às pessoas e famílias com direitos 
         <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
     </orgaoResponsavel>
     <orgaoPrestador>
-        <titulo>Município</titulo>
+        <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
         <endereco></endereco>
         <telefone></telefone>
     </orgaoPrestador>

--- a/src/main/resources/legado/programa-bolsa-familia-pbf.xml
+++ b/src/main/resources/legado/programa-bolsa-familia-pbf.xml
@@ -40,7 +40,7 @@ Para receber o Bolsa Família tem que se inscrever no Cadastro Único e quem rec
         <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
     </orgaoResponsavel>
     <orgaoPrestador>
-        <titulo>Município</titulo>
+        <titulo>Ministério do Desenvolvimento Social e Combate à Fome- MDS</titulo>
         <endereco></endereco>
         <telefone></telefone>
     </orgaoPrestador>


### PR DESCRIPTION
Decisão tomada após discussão sobre a #257: trocar o órgão "Município" e apontar todos os serviços para o Ministério do Desenvolvimento Social e Combate à Fome (MDS).