### PR TITLE
adicionando o ssh user and password no vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,8 @@ Vagrant.configure('2') do |config|
 
   config.vm.box = 'https://s3-sa-east-1.amazonaws.com/servicosgovbr/base.box'
   config.ssh.forward_agent = true
+  config.ssh.username = 'vagrant'
+  config.ssh.password = 'vagrant'
 
   if Vagrant.has_plugin? 'vagrant-cachier'
     config.cache.scope = :box


### PR DESCRIPTION
evita timeouts no momento do provisionamento das vms e tambem remove necessidade de se informar senha no primeiro vagrant up